### PR TITLE
Disable unused Nether Ores

### DIFF
--- a/config/powercrystals/netherores/common.cfg
+++ b/config/powercrystals/netherores/common.cfg
@@ -791,7 +791,7 @@ worldgen {
             I:BlocksPerGroup=4
 
             # Disables generation of Nikolite (overrides global ForceOreSpawn)
-            B:Disable=false
+            B:Disable=true
 
             # Force Nikolite to generate (overrides Disable)
             B:Force=false
@@ -924,7 +924,7 @@ worldgen {
             I:BlocksPerGroup=2
 
             # Disables generation of Iridium (overrides global ForceOreSpawn)
-            B:Disable=false
+            B:Disable=true
 
             # Force Iridium to generate (overrides Disable)
             B:Force=false
@@ -1000,7 +1000,7 @@ worldgen {
             I:BlocksPerGroup=6
 
             # Disables generation of Mithril (overrides global ForceOreSpawn)
-            B:Disable=false
+            B:Disable=true
 
             # Force Mithril to generate (overrides Disable)
             B:Force=false
@@ -1019,7 +1019,7 @@ worldgen {
             I:BlocksPerGroup=4
 
             # Disables generation of Adamantium (overrides global ForceOreSpawn)
-            B:Disable=false
+            B:Disable=true
 
             # Force Adamantium to generate (overrides Disable)
             B:Force=false
@@ -1057,7 +1057,7 @@ worldgen {
             I:BlocksPerGroup=8
 
             # Disables generation of Tungsten (overrides global ForceOreSpawn)
-            B:Disable=false
+            B:Disable=true
 
             # Force Tungsten to generate (overrides Disable)
             B:Force=false
@@ -1095,7 +1095,7 @@ worldgen {
             I:BlocksPerGroup=8
 
             # Disables generation of Tennantite (overrides global ForceOreSpawn)
-            B:Disable=false
+            B:Disable=true
 
             # Force Tennantite to generate (overrides Disable)
             B:Force=false


### PR DESCRIPTION
Thanks to permdaddy, modified from http://pastebin.com/wasqYKjs (keeping
Rutile and Magnesium for Mariculture's Titanium).
