### PR TITLE
Mekanism.cfg: Disable prefilled tanks in NEI

### DIFF
--- a/config/Mekanism.cfg
+++ b/config/Mekanism.cfg
@@ -52,7 +52,7 @@ general {
     I:ObsidianTNTDelay=100
     B:OpsBypassRestrictions=true
     I:OsmiumPerChunk=0
-    B:PrefilledPortableTanks=true
+    B:PrefilledPortableTanks=false
     D:RFToJoules=0.4
     I:SaltPerChunk=2
     D:SolarEvaporationSpeed=1.0


### PR DESCRIPTION
See https://github.com/aidancbrady/Mekanism/issues/2488 for this option.
Reduces NEI pagecount and lag.
